### PR TITLE
feat(M7.1): Hera capsule subsystem — init.4th boot protocol

### DIFF
--- a/Makefile.starkernel
+++ b/Makefile.starkernel
@@ -101,7 +101,7 @@ COMMON_CFLAGS := -std=c99 -Wall -Werror -Wextra \
                  $(ARCH_CFLAGS) \
                  -I$(KERNEL_INC) -Iinclude -Isrc -include $(STARFORTH_CONFIG_HEADER) \
                  -DPARITY_MODE=$(PARITY_MODE)
-VMCORE_CFLAGS_COMMON := $(filter-out -I$(KERNEL_INC),$(COMMON_CFLAGS)) -Iinclude -I. -Isrc/test_runner/include -Wno-error=unused-parameter -Wno-error=shift-negative-value -Wno-error=sign-compare
+VMCORE_CFLAGS_COMMON := $(filter-out -I$(KERNEL_INC),$(COMMON_CFLAGS)) -Iinclude -I. -Isrc/test_runner/include -Wno-error=unused-parameter -Wno-error=shift-negative-value -Wno-error=sign-compare -Wno-error=missing-field-initializers
 
 # Loader-specific flags
 LOADER_CFLAGS := $(COMMON_CFLAGS) -I$(KERNEL_SRC)/vm

--- a/capsules/init.4th
+++ b/capsules/init.4th
@@ -1,0 +1,9 @@
+\ capsules/init.4th - Hera bootstrap
+\
+\ This is the one init. Found by name at the capsule root.
+\ When Hera runs this she establishes her PERSONALITY:
+\   - Defines the capsule vocabulary
+\   - Sets up DoE feedback loops
+\   - Eventually births Hermes and Artemis
+
+." Hera init.4th loaded." CR

--- a/include/starkernel/capsule_generated.h
+++ b/include/starkernel/capsule_generated.h
@@ -1,0 +1,34 @@
+/*
+  StarForth — Steady-State Virtual Machine Runtime
+  Copyright (c) 2023–2025 Robert A. James
+  All rights reserved.
+  Licensed under the StarForth License, Version 1.0
+*/
+
+/**
+ * capsule_generated.h - Declarations for mkcapsule-generated capsule store.
+ *
+ * The matching capsule_generated.c is produced at build time by mkcapsule.
+ * These three arrays plus the directory header are compiled into .rodata.
+ */
+
+#ifndef STARKERNEL_CAPSULE_GENERATED_H
+#define STARKERNEL_CAPSULE_GENERATED_H
+
+#include <stdint.h>
+#include "starkernel/capsule.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern const uint8_t         capsule_arena[];
+extern const CapsuleDesc     capsule_descriptors[];
+extern const CapsuleNameEntry capsule_names[];
+extern const CapsuleDirHeader capsule_directory;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STARKERNEL_CAPSULE_GENERATED_H */

--- a/include/starkernel/vm/bootstrap/sk_vm_bootstrap.h
+++ b/include/starkernel/vm/bootstrap/sk_vm_bootstrap.h
@@ -63,6 +63,13 @@
  */
 int sk_vm_bootstrap_parity(ParityPacket *out);
 
+/**
+ * sk_get_mama_vm - Return opaque pointer to Mama's VM context.
+ *
+ * Valid after sk_vm_bootstrap_parity() succeeds.
+ */
+void *sk_get_mama_vm(void);
+
 #endif /* __STARKERNEL__ */
 
 #endif /* STARKERNEL_VM_BOOTSTRAP_SK_VM_BOOTSTRAP_H */

--- a/src/starkernel/kernel_main.c
+++ b/src/starkernel/kernel_main.c
@@ -33,6 +33,9 @@
 #ifdef STARFORTH_ENABLE_VM
 #include "starkernel/vm/bootstrap/sk_vm_bootstrap.h"
 #include "starkernel/vm/parity.h"
+#include "starkernel/capsule_birth.h"
+#include "starkernel/capsule_generated.h"
+#include "starkernel/kmalloc.h"
 #endif
 
 /* Helper: check if memory type is RAM */
@@ -234,6 +237,37 @@ void kernel_main(BootInfo *boot_info) {
         console_println("VM: parity bootstrap FAILED");
     } else {
         console_println("VM: parity bootstrap complete");
+    }
+
+    /* M7.1: Hera reads init.4th.
+     * capsule_arena lives in .rodata which may not be mapped after VMM takeover.
+     * Copy it to heap so the interpreter can safely read payload bytes. */
+    console_println("Hera: loading init.4th...");
+    void *mama_vm = sk_get_mama_vm();
+    CapsuleDirHeader live_dir = capsule_directory;
+    live_dir.arena_base = (uint64_t)(uintptr_t)capsule_arena;
+
+    uint8_t *arena_copy = (uint8_t *)kmalloc((size_t)live_dir.arena_size);
+    if (!arena_copy) {
+        console_println("Hera: arena alloc FAILED");
+    } else {
+        const uint8_t *src = capsule_arena;
+        uint8_t *dst = arena_copy;
+        size_t n = (size_t)live_dir.arena_size;
+        while (n--) *dst++ = *src++;
+        live_dir.arena_base = (uint64_t)(uintptr_t)arena_copy;
+
+        CapsuleRunResult cr = capsule_birth_mama(
+            mama_vm,
+            &live_dir,
+            capsule_descriptors,
+            capsule_names,
+            arena_copy);
+        if (cr == CAPSULE_RUN_OK) {
+            console_println("Hera: init.4th OK");
+        } else {
+            console_println("Hera: init.4th FAILED");
+        }
     }
 #else
     console_println("=== LithosAnanke Checkpoint ===");

--- a/src/starkernel/vm/bootstrap/sk_vm_bootstrap.c
+++ b/src/starkernel/vm/bootstrap/sk_vm_bootstrap.c
@@ -134,8 +134,14 @@ static void sk_bootstrap_debug_log_xt(const char *label, const DictEntry *entry)
 
 #if STARFORTH_ENABLE_VM
 
+static VM sk_mama_vm;  /* Mama's VM — persists after bootstrap */
+
+void *sk_get_mama_vm(void) {
+    return (void *)&sk_mama_vm;
+}
+
 int sk_vm_bootstrap_parity(ParityPacket *out) {
-    static VM vm;            /* Static to avoid large stack frame */
+    VM *vm = &sk_mama_vm;
     ParityPacket local_pkt;
     ParityPacket *pkt = out ? out : &local_pkt;
 
@@ -146,10 +152,10 @@ int sk_vm_bootstrap_parity(ParityPacket *out) {
     sk_hal_init();
     sf_time_init();
 
-    vm_init_with_host(&vm, sk_hal_host_services());
-    if (vm.error) {
+    vm_init_with_host(vm, sk_hal_host_services());
+    if (vm->error) {
         console_println("VM: init failed");
-        sk_parity_collect(&vm, pkt);
+        sk_parity_collect(vm, pkt);
         sk_parity_print(pkt);
         return -1;
     }
@@ -161,14 +167,14 @@ int sk_vm_bootstrap_parity(ParityPacket *out) {
 #endif
 
     /* Enable interpreter - required for POST to execute vm_interpret() calls */
-    vm_enable_interpreter(&vm);
+    vm_enable_interpreter(vm);
 
     /* Run full POST (Power-On Self Test) */
     console_println("POST: Running comprehensive test suite...");
-    run_all_tests(&vm);
+    run_all_tests(vm);
 
     /* Collect and print parity (includes test results) */
-    sk_parity_collect(&vm, pkt);
+    sk_parity_collect(vm, pkt);
     sk_parity_print(pkt);
 
     /* Verify POST success: parity OK, no test failures, no test errors */


### PR DESCRIPTION
## Summary

- Adds the full capsule subsystem (M7.1): `CapsuleDesc`, `CapsuleDirHeader`, `CapsuleNameEntry`, xxHash64, validation, find, birth, run
- Implements `mkcapsule` host tool that walks the capsule tree and generates `capsule_generated.c` (content-addressed, linked into `.rodata`)
- `capsules/init.4th` at tree root carries `CAPSULE_FLAG_MAMA_INIT`; `capsule_birth_mama()` finds it by flag and runs it on Hera's VM
- Suppresses `-Werror=missing-field-initializers` for vmcore test modules (kernel build only)
- **Fixes triple fault**: `capsule_arena` lives in `.rodata` which is not mapped after VMM takeover — heap-copies the arena before passing it to the interpreter
- Promotes bootstrap VM to file-static `sk_mama_vm` so Hera's context persists after POST; adds `sk_get_mama_vm()` accessor

## Test plan

- [ ] `make -f Makefile.starkernel` — kernel builds cleanly (no VM)
- [ ] `make -f Makefile.starkernel STARFORTH_ENABLE_VM=1` — kernel builds with VM
- [ ] QEMU boot reaches `Hera: init.4th OK` without triple fault

https://claude.ai/code/session_01My9xyoPonj2WaouRmPJdVJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01My9xyoPonj2WaouRmPJdVJ)_